### PR TITLE
Code reformatting and Readme typos

### DIFF
--- a/MapBuilder.java
+++ b/MapBuilder.java
@@ -16,7 +16,6 @@ import java.util.List;
 public class MapBuilder {
 
     public static final String VERSION = "1.2";
-
     private MapView map;
     private BufferedImage image;
     private List<Text> texts;
@@ -108,7 +107,6 @@ public class MapBuilder {
         return this;
     }
 
-
     /**
      * Builds an itemstack of the map.
      *
@@ -117,27 +115,20 @@ public class MapBuilder {
     @SuppressWarnings("deprecation")
     public ItemStack build() {
         ItemStack item = new ItemStack(Material.MAP);
-
         map = Bukkit.createMap(Bukkit.getWorlds().get(0));
         List<MapRenderer> old = map.getRenderers();
-
         map.setScale(Scale.NORMAL);
         map.getRenderers().forEach(map::removeRenderer);
-
         map.addRenderer(new MapRenderer() {
             @Override
             public void render(MapView mapView, MapCanvas mapCanvas, Player player) {
-                if (rendered && renderOnce) {
+                if (rendered && renderOnce)
                     return;
-                }
-
                 if (player == null || !player.isOnline()) {
                     old.forEach(map::addRenderer);
                 } else {
-                    if (image != null) {
+                    if (image != null)
                         mapCanvas.drawImage(0, 0, image);
-
-                    }
                     texts.forEach(text -> mapCanvas.drawText(text.getX(), text.getY(), text.getFont(), text.getText()));
                     mapCanvas.setCursors(cursors);
                     rendered = true;
@@ -152,7 +143,6 @@ public class MapBuilder {
         } else {
             item.setDurability(getMapId(map));
         }
-
         return item;
     }
 
@@ -210,7 +200,6 @@ public class MapBuilder {
 }
 
 class Text {
-
     private int x;
     private int y;
     private MapFont font;

--- a/MapBuilder.java
+++ b/MapBuilder.java
@@ -1,37 +1,42 @@
 package me.lagbug.common.builders;
 
-import java.awt.image.BufferedImage;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.MapMeta;
-import org.bukkit.map.MapCanvas;
-import org.bukkit.map.MapCursorCollection;
-import org.bukkit.map.MapFont;
-import org.bukkit.map.MapRenderer;
-import org.bukkit.map.MapView;
+import org.bukkit.map.*;
 import org.bukkit.map.MapView.Scale;
+
+import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MapBuilder {
 
-	public static final String VERSION = "1.1";
-	
+
     private MapView map;
     private BufferedImage image;
     private List<Text> texts;
     private MapCursorCollection cursors;
-    private boolean rendered, renderOnce;
+    private boolean rendered;
+    private boolean renderOnce;
 
     public MapBuilder() {
         cursors = new MapCursorCollection();
         texts = new ArrayList<>();
         rendered = false;
         renderOnce = true;
+    }
+
+    /**
+     * Get the image that's being used
+     *
+     * @return the image used
+     */
+    public BufferedImage getImage() {
+        return image;
     }
 
     /**
@@ -44,44 +49,35 @@ public class MapBuilder {
         this.image = image;
         return this;
     }
-    
-    /**
-     * Get the image that's being used
-     *
-     * @return the image used
-     */
-    public BufferedImage getImage() {
-    	return image;
-    }
 
     /**
      * Set and image to be used
      *
-     * @param x, y the coordinates to add the text
+     * @param x,   y the coordinates to add the text
      * @param font the font to be used
-     * @param text the string that will be displayed 
+     * @param text the string that will be displayed
      * @return the instance of this class
      */
     public MapBuilder addText(int x, int y, MapFont font, String text) {
         this.texts.add(new Text(x, y, font, text));
         return this;
     }
-    
+
     /**
      * Gets the list of all the texts used
      *
      * @return an array list of all the texts
      */
     public List<Text> getTexts() {
-    	return texts;
+        return texts;
     }
 
     /**
      * Adds a cursor to the map
      *
-     * @param x, y the coordinates to add the cursor
+     * @param x,        y the coordinates to add the cursor
      * @param direction the direction to display the cursor
-     * @param type the type of the cursor
+     * @param type      the type of the cursor
      * @return the instance of this class
      */
     @SuppressWarnings("deprecation")
@@ -89,16 +85,16 @@ public class MapBuilder {
         cursors.addCursor(x, y, (byte) direction.getId(), (byte) type.getId());
         return this;
     }
-    
+
     /**
      * Gets all the currently used cursors
      *
      * @return an array list of all the texts
      */
     public MapCursorCollection getCursors() {
-    	return cursors;
+        return cursors;
     }
-    
+
     /**
      * Sets whether the image should only be rendered once.
      * Good for static images and reduces lag.
@@ -107,11 +103,11 @@ public class MapBuilder {
      * @return the instance of this class
      */
     public MapBuilder setRenderOnce(boolean renderOnce) {
-    	this.renderOnce = renderOnce;
-    	return this;
+        this.renderOnce = renderOnce;
+        return this;
     }
 
-    
+
     /**
      * Builds an itemstack of the map.
      *
@@ -133,7 +129,7 @@ public class MapBuilder {
                 if (rendered && renderOnce) {
                     return;
                 }
-            
+
                 if (player == null || !player.isOnline()) {
                     old.forEach(map::addRenderer);
                 } else {
@@ -145,10 +141,9 @@ public class MapBuilder {
                     mapCanvas.setCursors(cursors);
                     rendered = true;
                 }
-                return;
             }
         });
-    
+
         if (Bukkit.getVersion().contains("1.13") || Bukkit.getVersion().contains("1.14")) {
             MapMeta mapMeta = (MapMeta) item.getItemMeta();
             mapMeta.setMapId(getMapId(map));
@@ -159,7 +154,7 @@ public class MapBuilder {
 
         return item;
     }
- 
+
     /**
      * Gets a map id cross-version using reflection
      *
@@ -180,7 +175,7 @@ public class MapBuilder {
             }
         }
     }
- 
+
     public enum CursorDirection {
         SOUTH(0), SOUTH_WEST_SOUTH(1), SOUTH_WEST(2), SOUTH_WEST_WEST(3), WEST(4), NORTH_WEST_WEST(5), NORTH_WEST(6),
         NORTH_WEST_NORTH(7), NORTH(8), NORTH_EAST_NORTH(9), NORTH_EAST(10), NORTH_EAST_EAST(11), EAST(12),
@@ -196,7 +191,7 @@ public class MapBuilder {
             return this.id;
         }
     }
- 
+
     public enum CursorType {
         WHITE_POINTER(0), GREEN_POINTER(1), RED_POINTER(2), BLUE_POINTER(3), WHITE_CLOVER(4), RED_BOLD_POINTER(5),
         WHITE_DOT(6), LIGHT_BLUE_SQUARE(7);
@@ -215,15 +210,16 @@ public class MapBuilder {
 
 class Text {
 
-    private int x, y;
+    private int x;
+    private int y;
     private MapFont font;
-    private String text;
+    private String string;
 
     public Text(int x, int y, MapFont font, String text) {
         setX(x);
         setY(y);
         setFont(font);
-        setText(text);
+        setString(text);
     }
 
     public int getX() {
@@ -250,11 +246,11 @@ class Text {
         this.font = font;
     }
 
-    public String getText() {
-        return text;
+    public String getString() {
+        return string;
     }
 
-    public void setText(String text) {
-        this.text = text;
+    public void setString(String string) {
+        this.string = string;
     }
 }

--- a/MapBuilder.java
+++ b/MapBuilder.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 public class MapBuilder {
 
+    public static final String VERSION = "1.2";
 
     private MapView map;
     private BufferedImage image;

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Cross-version compatible. This can be used from 1.8 to 1.14 with no errors.
 Really good for static (non-updating) images.
 
 ## Usage
-This is really simple to use and will return an itemstack which you can then use to give it to a player for example. In this example, a map is given to all online players.
+This is really simple to use and will return an ItemStack which you can then use to give it to a player for example. In this example, a map is given to all online players.
 
 ```java
 Bukkit.getOnlinePlayers().forEach(player -> { //Looping through all online player using lambda
-    ItemStack item = null; //Initiating the itemstack
+    ItemStack item = null; //Initiating the ItemStack
     try { 
         item = new MapBuilder().setRenderOnce(true).setImage(ImageIO.read(new URL("https://site.com/image.png"))) //Initializing the utility class and setting an image as background
-                .addText(0, 0, MinecraftFont.Font, "Hello there") //Adding some text with minecraft default font at 0, 0
+                .addText(0, 0, MinecraftFont.Font, "Hello there") //Adding some text with Minecaft default font at 0, 0
                 .addCursor(20, 20, CursorDirection.EAST, CursorType.WHITE_DOT).build(); //Adding a cursor (in our case a white dot) to the map
     } catch (IOException e) { //Exception thrown if url is invalid
             e.printStackTrace();
@@ -33,5 +33,5 @@ Bukkit.getOnlinePlayers().forEach(player -> { //Looping through all online playe
 ```
 
 ## Result
-You can really easily achive something like this
+You can really easily archive something like this
 ![alt text](https://i.ibb.co/qNnqC6C/Screenshot-1.png)


### PR DESCRIPTION
Renamed 'text' field in 'text' class to 'string'. A field should not duplicate the name of its containing class.

Seperated multiple variables that where declared on the same line into seperate lines.

Line 149: Jump/Return statements should not be redundant. This is a return statement at the end of the method, it isn't needed.

Reorganized imports.

Reduced file size by removing whitespace and removing curly brackets on 1 line if-statements.